### PR TITLE
Update targeted-dictionary-analysis.markdown

### DIFF
--- a/content/advanced-operations/targeted-dictionary-analysis.markdown
+++ b/content/advanced-operations/targeted-dictionary-analysis.markdown
@@ -8,6 +8,7 @@ draft: false
 ```r
 require(quanteda)
 require(lubridate)
+require(quanteda.corpora)
 ```
 
 This corpus contains 6,000 Guardian news articles from 2012 to 2016.


### PR DESCRIPTION
It appreas that "require(quanteda.corpora)" is required for the download.