### PR TITLE
Update targeted-dictionary-analysis.Rmarkdown

### DIFF
--- a/content/advanced-operations/targeted-dictionary-analysis.Rmarkdown
+++ b/content/advanced-operations/targeted-dictionary-analysis.Rmarkdown
@@ -7,6 +7,7 @@ draft: false
 ```{r message=FALSE}
 require(quanteda)
 require(lubridate)
+require(quanteda.corpora)
 ```
 
 This corpus contains 6,000 Guardian news articles from 2012 to 2016.


### PR DESCRIPTION
The library statement "require(quanteda.corpora)" is required for the download function to work.  If you haven't performed any other tutorial, then this call will fail.