### PR TITLE
toks_inside is overwritten

### DIFF
--- a/content/advanced-operations/target-word-collocations.markdown
+++ b/content/advanced-operations/target-word-collocations.markdown
@@ -31,7 +31,7 @@ We select two tokens objects for words inside and outside of the 10-word windows
 ```r
 eu <- c("EU", "europ*", "european union")
 toks_inside <- tokens_keep(toks_news, pattern = eu, window = 10)
-toks_inside <- tokens_remove(toks_news, pattern = eu) # remove the patterns
+toks_inside <- tokens_remove(toks_inside, pattern = eu) # remove the patterns
 toks_outside <- tokens_remove(toks_news, pattern = eu, window = 10)
 ```
 


### PR DESCRIPTION
Hi, 

thanks for this awesome package. Have been using it a lot in the past. 
I might be wrong here, but should it not be that we select the 10 word window around the keywords and then delete the keywords from these patterns, but not overwrite the entire tokens object with the full tokens object again? 
Proposed the relevant change above.

thank you very much again!