### PR TITLE
fix positive class for caret::confusionMatrix

### DIFF
--- a/content/machine-learning/nb.Rmarkdown
+++ b/content/machine-learning/nb.Rmarkdown
@@ -72,7 +72,7 @@ From the cross-table we see that the number of false positives and false negativ
 We can use the function `confusionMatrix()` from the **caret** package to assess the performance of the classification.
 
 ```{r}
-confusionMatrix(tab_class, mode = "everything")
+confusionMatrix(tab_class, mode = "everything", positive = "pos")
 ```
 
 {{% notice note %}}


### PR DESCRIPTION
In the [Naive Bayes tutorial](https://tutorials.quanteda.io/machine-learning/nb/), the caret confusion matrix at the bottom is using "neg" as the positive class, instead of "pos".

![Screen Shot 2021-11-18 at 14 08 27](https://user-images.githubusercontent.com/1353756/142412731-5d8dab86-498a-41ec-9df4-b45e2d444971.png)


