### PR TITLE
Misspelling of padding in tok_news definition

### DIFF
--- a/content/advanced-operations/compound-mutiword-expressions.markdown
+++ b/content/advanced-operations/compound-mutiword-expressions.markdown
@@ -29,7 +29,7 @@ We remove punctuation marks and symbols in `tokens()` and stopwords in `tokens_r
 
 
 ```r
-toks_news <- tokens(corp_news, remove_punct = TRUE, remove_symbols = TRUE, pading = TRUE) %>% 
+toks_news <- tokens(corp_news, remove_punct = TRUE, remove_symbols = TRUE, padding = TRUE) %>% 
     tokens_remove(stopwords("en"), padding = TRUE)
 ```
 


### PR DESCRIPTION
toks_news <- tokens(corp_news, remove_punct = TRUE, remove_symbols = TRUE, pading = TRUE) %>% 
    tokens_remove(stopwords("en"), padding = TRUE)